### PR TITLE
Fix TP Tomes being incorrectly saved as ID Tome

### DIFF
--- a/src/d2/items.ts
+++ b/src/d2/items.ts
@@ -387,7 +387,9 @@ export async function writeItem(
       writer.WriteUInt8(0x00, 7);
     }
 
-    if (item.type === "tbk" || item.type === "ibk") {
+    if (item.type === "tbk") {
+      writer.WriteUInt8(0, 5);
+    } else if (item.type === "ibk") {
       writer.WriteUInt8(1, 5);
     }
 


### PR DESCRIPTION
When reading and then immediately writing a character, town portal tomes have a bit set incorrectly to `1`, when it should be `0`. As a result they act as identity tomes in both d2 & d2r. This PR fixes the issue. Lint passes, tests pass. 

This fixes several downstream issues in [d2s-editor](https://github.com/dschu012/d2s-editor), specifically: [3](https://github.com/dschu012/d2s-editor/issues/3), [44](https://github.com/dschu012/d2s-editor/issues/44), [45](https://github.com/dschu012/d2s-editor/issues/45), [73](https://github.com/dschu012/d2s-editor/issues/73), [74](https://github.com/dschu012/d2s-editor/issues/74)